### PR TITLE
fix(validation): correct logic in notEmptyOrNull to reject null values

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -131,26 +131,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -229,5 +229,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/validations/not_empty_validation.dart
+++ b/lib/src/validations/not_empty_validation.dart
@@ -79,7 +79,7 @@ extension NotEmptyOrNullableValidation on SimpleValidationBuilder<String?> {
   SimpleValidationBuilder<String?> notEmptyOrNull(
       {String? message, String? code}) {
     return useValidation(
-      (value, entity) => value == null || value.isNotEmpty,
+      (value, entity) => value != null && value.isNotEmpty,
       code: code ?? Language.code.notEmpty,
       message: message,
     );

--- a/test/src/validations/not_empty_validation_test.dart
+++ b/test/src/validations/not_empty_validation_test.dart
@@ -29,6 +29,43 @@ void main() {
 
     final result = validator.validate(user);
 
-    expect(result.isValid, true);
+    expect(result.isValid, false);
+  });
+
+  group('NotEmptyOrNullableValidation', () {
+    late TestLucidValidator<UserNullableModel> validator;
+
+    setUp(() {
+      validator = TestLucidValidator<UserNullableModel>();
+      validator
+          .ruleFor((user) => user.password, key: 'password')
+          .notEmptyOrNull();
+    });
+
+    test('should fail when string is null', () {
+      final entity = UserNullableModel()..password = null;
+      final result = validator.validate(entity);
+
+      expect(result.isValid, isFalse);
+      expect(result.exceptions, hasLength(1));
+      expect(result.exceptions.first.key, equals('password'));
+    });
+
+    test('should fail when string is empty', () {
+      final entity = UserNullableModel()..password = '';
+      final result = validator.validate(entity);
+
+      expect(result.isValid, isFalse);
+      expect(result.exceptions, hasLength(1));
+      expect(result.exceptions.first.key, equals('password'));
+    });
+
+    test('should pass when string is not null and not empty', () {
+      final entity = UserNullableModel()..password = 'ValidPassword123';
+      final result = validator.validate(entity);
+
+      expect(result.isValid, isTrue);
+      expect(result.exceptions, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR fixes a logic bug in the `notEmptyOrNull` extension method on `SimpleValidationBuilder<String?>`.

Previously, the predicate condition was:

```dart
(value, entity) => value == null || value.isNotEmpty
````

This caused `null` values to evaluate as valid, effectively bypassing the validation rule when the field was `null`.

### Changes Made

* Updated the predicate condition in `NotEmptyOrNullableValidation` to:

```dart
(value, entity) => value != null && value.isNotEmpty
```

* Added unit tests to the `NotEmptyOrNullableValidation` group covering:

  * `null` values
  * Empty strings (`""`)
  * Valid non-empty strings

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have added tests that prove my fix is effective
* [x] All new and existing tests passed (`dart test`)